### PR TITLE
Pin to exact TypeScript version

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import fs = require('fs');
 import os = require('os');
 import path = require('path');

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "npm run prepare && mocha"
   },
   "dependencies": {
-    "typescript": "^5.0.3"
+    "typescript": "5.0.3"
   },
   "devDependencies": {
     "@types/node": "^6.0.111",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build",
-    "test": "npm run prepare && mocha"
+    "test": "npm run prepare && mocha",
+    "postinstall": "npm run build"    
   },
   "dependencies": {
     "typescript": "5.0.3"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
         "declaration": true,
         "removeComments": false,
         "stripInternal": true,
+        "types": [],
+        "typeRoots": [],
         // since 2.3
         // "strict": true,
         "alwaysStrict": true,


### PR DESCRIPTION
The TypeScript transpilation in PulsarNext is broken because it's trying to install the latest v5 of `typescript`. But at some point the expectations changed regarding options — some internal method went from expecting a `compilerOptions` object to the parent object — the object that corresponds to the top level of a `tsconfig.json`.

Poor form for TypeScript to violate semver, but I suppose if they bumped major version with every possible breaking change they'd be in triple digits by now.

Anyway, one possible fix is to pin to the exact version. We could also bump to the latest `typescript` and give it the object it expects… but, honestly, TypeScript transpilation isn't the greatest idea that Atom ever had, and it's not worth investing a lot of time in.